### PR TITLE
Don't assume that all flavors have been configured.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ if (project.ext.release) {
 }
 
 group = 'com.vandalsoftware.tools.gradle'
-version = getVersion('0.3.0')
+version = getVersion('0.3.1')
 
 jar {
     baseName 'robolectric'

--- a/src/main/groovy/com/vandalsoftware/tools/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/com/vandalsoftware/tools/gradle/RobolectricPlugin.groovy
@@ -122,7 +122,9 @@ class RobolectricPlugin implements Plugin<Project> {
             addConfigToTestTask(extension.defaultConfig, testTask)
             addConfigToTestTask(debugTestConfig, testTask)
             variant.productFlavors.each {
-                addConfigToTestTask(extension.productFlavors[it.name], testTask)
+                if (extension.hasProperty(it.name)) {
+                    addConfigToTestTask(extension.productFlavors[it.name], testTask)
+                }
             }
             testTask.reports.html.destination = project.reporting.file(testVariantOutputDirName)
             testTask.reports.junitXml.destination = testResultsOutput


### PR DESCRIPTION
Only apply a flavor-specific configuration if it exists in the extension
configuration.
